### PR TITLE
amp-c: Remove flow-control macros

### DIFF
--- a/amp-c.sh
+++ b/amp-c.sh
@@ -8,45 +8,6 @@ then
     exit 1
 fi
 
-level=""
-function p {
-    new="$1"
-    shift
-    case "$new" in
-        "book")
-            case "$level" in
-                "reg")
-                    echo -en "\t}\n\n"
-                    ;;
-            esac
-            echo -en "\t"
-            ;;
-        "page")
-            case "$level" in
-                "reg")
-                    echo -en "\t}\n\n"
-                    ;;
-            esac
-            echo -en "\t"
-            ;;
-        "reg")
-            case "$level" in
-                "book")
-                    echo -en "\t{\n"
-                    echo -en "\t\t// Page 0\n\n"
-                    ;;
-                "page")
-                    echo -en "\t{\n"
-                    ;;
-            esac
-            echo -en "\t\t"
-            ;;
-    esac
-    echo -en "$@"
-    level="$new"
-}
-
-book="0x00"
 page="0x00"
 function s {
     reg="$1"
@@ -54,26 +15,30 @@ function s {
 
     if [[ "$reg" = "0x00" ]]
     then
-        p page "amp_set_page($@);\n"
+        echo -en "\tres = tas5825m_set_page(dev, $@);\n"
+        echo -en "\tif (res < 0)\n"
+        echo -en "\t\treturn res;\n\n"
         page="$@"
     elif [[ "$page" = "0x00" && "$reg" = "0x7F" ]]
     then
-        echo
-        p book "amp_set_book($@);\n"
-        echo
-        book="$@"
+        echo -en "\tres = tas5825m_set_book(dev, $@);\n"
+        echo -en "\tif (res < 0)\n"
+        echo -en "\t\treturn res;\n\n"
     else
         if [[ "$#" = "1" ]]
         then
-            p reg "amp_write_at($reg, $@);\n"
+            echo -en "\tres = tas5825m_write_at(dev, $reg, $@);\n"
+            echo -en "\tif (res < 0)\n"
+            echo -en "\t\treturn res;\n\n"
         else
-            p reg "amp_write_block_at($reg, {\n"
+            echo -en "\t{\n"
+            echo -en "\t\tconst uint8_t values[] = {"
             i="0"
             for arg in "$@"
             do
                 if [[ "$i" = "0" ]]
                 then
-                    p reg "\t"
+                    echo -en "\n\t\t\t"
                 else
                     echo -n ", "
                 fi
@@ -82,11 +47,14 @@ function s {
                 if [[ "$i" = "8" ]]
                 then
                     i="0"
-                    echo ","
+                    echo -n ","
                 fi
             done
-            echo
-            p reg "});\n"
+            echo -en "\n\t\t};\n"
+            echo -en "\t\tres = tas5825m_write_block_at(dev, $reg, values, ARRAY_SIZE(values));\n"
+            echo -en "\t\tif (res < 0)\n"
+            echo -en "\t\t\treturn res;\n"
+            echo -en "\t}\n\n"
         fi
     fi
 }
@@ -96,26 +64,9 @@ cat <<"EOF"
 
 #include <drivers/i2c/tas5825m/tas5825m.h>
 
-#define R(F) { \
-	res = F; \
-	if (res < 0) \
-		return res; \
-}
-
-#define amp_write_at(A, V) R(tas5825m_write_at(dev, A, V))
-
-#define amp_write_block_at(A, ...) { \
-	const uint8_t _values[] = __VA_ARGS__; \
-	R(tas5825m_write_block_at(dev, A, _values, ARRAY_SIZE(_values))); \
-}
-
-#define amp_set_page(P) R(tas5825m_set_page(dev, P))
-
-#define amp_set_book(B) R(tas5825m_set_book(dev, B))
-
 int tas5825m_setup(struct device *dev, int id)
 {
-	int res = 0;
+	int res;
 
 EOF
 
@@ -125,8 +76,6 @@ do
 done
 
 cat <<"EOF"
-	}
-
 	return 0;
 }
 EOF


### PR DESCRIPTION
Per feedback from coreboot review of oryp5, remove flow-control macros from the generated C code.